### PR TITLE
fix mesh/rotate error and README typo

### DIFF
--- a/PointCloudVis.py
+++ b/PointCloudVis.py
@@ -88,5 +88,6 @@ class PointCloudVis:
 		[vis.add_geometry(element) for element in boxes_o3d]
 
 		vis.get_render_option().point_size = 2
+		vis.get_render_option().background_color = np.asarray([0, 0, 0])
 		vis.run()
 		vis.destroy_window()

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Download KITTI dataset and create some directories first:
 
 ## Demo
 ```
-$ python visiualize.py
+$ python visualize.py
 ```
 
-If you has your own data path, you  can run like this:
+If you has your own data path, you can run like this:
 ```
-$ python visiualize.py --data=KITTI_DATASET_ROOT --frame=500
+$ python visualize.py --data=KITTI_DATASET_ROOT --frame=500
 ```

--- a/open3d_geometry/open3d_arrow.py
+++ b/open3d_geometry/open3d_arrow.py
@@ -79,8 +79,11 @@ def create_arrow(origin=[0,0,0],end=None,color = None, vec=None):
 	mesh = get_arrow(scale)
 	# mesh.transform(T)
 
-	rot_matrix = R.from_euler('xyz', [0,0,gamma]).as_matrix()
-	mesh.rotate(rot_matrix, center=np.array([[0,0], [0,0], [0,0]]))
+	beta_rotation = R.from_euler('xyz', [0,beta,0]).as_matrix()
+	mesh.rotate(beta_rotation, center=mesh.get_center())
+
+	gamma_rotation = R.from_euler('xyz', [0,0,gamma]).as_matrix()
+	mesh.rotate(gamma_rotation, center=mesh.get_center())
 
 	mesh.translate(origin)
 

--- a/open3d_geometry/open3d_arrow.py
+++ b/open3d_geometry/open3d_arrow.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 import open3d as o3d
-
+from scipy.spatial.transform import Rotation as R
 
 def vector_magnitude(vec):
 	"""
@@ -78,8 +78,10 @@ def create_arrow(origin=[0,0,0],end=None,color = None, vec=None):
 		gamma,beta = calculate_zy_rotation_for_arrow(vec)
 	mesh = get_arrow(scale)
 	# mesh.transform(T)
-	mesh.rotate([0,beta,0],center=False)
-	mesh.rotate([0,0,gamma],center=False)
+
+	rot_matrix = R.from_euler('xyz', [0,0,gamma]).as_matrix()
+	mesh.rotate(rot_matrix, center=np.array([[0,0], [0,0], [0,0]]))
+
 	mesh.translate(origin)
 
 	# add color


### PR DESCRIPTION
Fixes the following error when running `visualize.py`:

```
Traceback (most recent call last):
File "/open3d-kitti-visualization/visualize.py", line 51, in <module>
vis_kitti(data_path, frame)
File "/open3d-kitti-visualization/visualize.py", line 37, in vis_kitti
PointCloudVis.draw_points_with_boxes(points, boxes_velo, box_colors)
File "/open3d-kitti-visualization/PointCloudVis.py", line 60, in draw_points_with_boxes
box_o3d, arrow = create_box_from_dim_with_arrow(dim, color)
File "/open3d-kitti-visualization/open3d_geometry/open3d_box.py", line 54, in create_box_from_dim_with_arrow
arrow = create_arrow(a_start, a_end, color)
File "/open3d-kitti-visualization/open3d_geometry/open3d_arrow.py", line 86, in create_arrow
mesh.rotate([0,0,gamma],center=False)
TypeError: rotate(): incompatible function arguments. The following argument types are supported:
1. (self: open3d.cuda.pybind.geometry.Geometry3D, R: numpy.ndarray[numpy.float64[3, 3]]) -> open3d.cuda.pybind.geometry.Geometry3D
2. (self: open3d.cuda.pybind.geometry.Geometry3D, R: numpy.ndarray[numpy.float64[3, 3]], center: numpy.ndarray[numpy.float64[3, 1]]) -> open3d.cuda.pybind.geometry.Geometry3D

Invoked with: TriangleMesh with 124 points and 240 triangles., [0, 0, 0.009203673205103513]; kwargs: center=False
```